### PR TITLE
Fixing strconv.ParseInt errors while using Info() method

### DIFF
--- a/server_cmds.go
+++ b/server_cmds.go
@@ -23,7 +23,7 @@ type Server struct {
 	HostBannerGFXInterval                  int     `ms:"virtualserver_hostbanner_gfx_interval"`
 	HostMessageMode                        int     `ms:"virtualserver_hostmessage_mode"`
 	ID                                     int     `ms:"virtualserver_id"`
-	MachineID                              int     `ms:"virtualserver_machine_id"`
+	MachineID                              string  `ms:"virtualserver_machine_id"` // MachineID can be empty; int-conversion fails in this case
 	MaxClients                             int     `ms:"virtualserver_maxclients"`
 	MinClientsInChannelBeforeForcedSilence int     `ms:"virtualserver_min_clients_in_channel_before_forced_silence"`
 	NeededIdentitySecurityLevel            int     `ms:"virtualserver_needed_identity_security_level"`
@@ -52,7 +52,7 @@ type Server struct {
 	MinClientVersion                       int     `ms:"virtualserver_min_client_version"`
 	MiniOSVersion                          int     `ms:"virtualserver_min_ios_version"`
 	ReserverSlots                          int     `ms:"virtualserver_reserved_slots"`
-	TotalPing                              int     `ms:"virtualserver_total_ping"`
+	TotalPing                              float32 `ms:"virtualserver_total_ping"` // TotalPing can be float; int-conversion fails in this case
 	MaxDownloadTotalBandwidth              uint64  `ms:"virtualserver_max_download_total_bandwidth"`
 	MaxUploadTotalBandwidth                uint64  `ms:"virtualserver_max_upload_total_bandwidth"`
 	MonthBytesDownloaded                   int64   `ms:"virtualserver_MonthBytesDownloaded"`

--- a/server_cmds.go
+++ b/server_cmds.go
@@ -23,7 +23,7 @@ type Server struct {
 	HostBannerGFXInterval                  int     `ms:"virtualserver_hostbanner_gfx_interval"`
 	HostMessageMode                        int     `ms:"virtualserver_hostmessage_mode"`
 	ID                                     int     `ms:"virtualserver_id"`
-	MachineID                              string  `ms:"virtualserver_machine_id"` // MachineID can be empty; int-conversion fails in this case
+	MachineID                              string  `ms:"virtualserver_machine_id"`
 	MaxClients                             int     `ms:"virtualserver_maxclients"`
 	MinClientsInChannelBeforeForcedSilence int     `ms:"virtualserver_min_clients_in_channel_before_forced_silence"`
 	NeededIdentitySecurityLevel            int     `ms:"virtualserver_needed_identity_security_level"`
@@ -52,7 +52,7 @@ type Server struct {
 	MinClientVersion                       int     `ms:"virtualserver_min_client_version"`
 	MiniOSVersion                          int     `ms:"virtualserver_min_ios_version"`
 	ReserverSlots                          int     `ms:"virtualserver_reserved_slots"`
-	TotalPing                              float32 `ms:"virtualserver_total_ping"` // TotalPing can be float; int-conversion fails in this case
+	TotalPing                              float32 `ms:"virtualserver_total_ping"`
 	MaxDownloadTotalBandwidth              uint64  `ms:"virtualserver_max_download_total_bandwidth"`
 	MaxUploadTotalBandwidth                uint64  `ms:"virtualserver_max_upload_total_bandwidth"`
 	MonthBytesDownloaded                   int64   `ms:"virtualserver_MonthBytesDownloaded"`

--- a/server_cmds_test.go
+++ b/server_cmds_test.go
@@ -41,7 +41,7 @@ func TestCmdsServer(t *testing.T) {
 				Uptime:             12345025,
 				Name:               "Server #1",
 				AutoStart:          true,
-				MachineID:          1,
+				MachineID:          "1",
 				UniqueIdentifier:   "uniq1",
 			},
 			{
@@ -54,7 +54,7 @@ func TestCmdsServer(t *testing.T) {
 				Uptime:             3165117,
 				Name:               "Server #2",
 				AutoStart:          true,
-				MachineID:          1,
+				MachineID:          "1",
 				UniqueIdentifier:   "uniq2",
 			},
 		}


### PR DESCRIPTION
When testing your code with my Teamspeak3 server I ran into two errors while reading the server info.

    * cannot parse 'virtualserver_machine_id' as int: strconv.ParseInt: parsing "": invalid syntax
    * cannot parse 'virtualserver_total_ping' as int: strconv.ParseInt: parsing "38.3333": invalid syntax

Apparently the machine_id can also be an empty string (?!) and thereby the conversion to integer fails. Same thing with total_ping: In my case it's outputted as a float value. I changed the type mapping in `server_cmds.go` and it works perfectly.

For the record: I'm running Teamspeak3 server version 3.0.13.7 [Build: 1498547480] on Linux Debian using a non-profit license.