### PR TITLE
Added whoami command support

### DIFF
--- a/basic_cmds.go
+++ b/basic_cmds.go
@@ -43,3 +43,28 @@ func (c *Client) UsePort(port int) error {
 	_, err := c.ExecCmd(NewCmd("use").WithArgs(NewArg("port", port)))
 	return err
 }
+
+// ConnectionInfo represents an answer of the whoami command.
+type ConnectionInfo struct {
+	ServerStatus           string `ms:"virtualserver_status"`
+	ServerID               int    `ms:"virtualserver_id"`
+	ServerUniqueIdentifier string `ms:"virtualserver_unique_identifier"`
+	ServerPort             int    `ms:"virtualserver_port"`
+	ClientID               int    `ms:"client_id"`
+	ClientChannelID        int    `ms:"client_channel_id"`
+	ClientName             string `ms:"client_nickname"`
+	ClientDatabaseID       int    `ms:"client_database_id"`
+	ClientLoginName        string `ms:"client_login_name"`
+	ClientUniqueIdentifier string `ms:"client_unique_identifier"`
+	ClientOriginServerID   int    `ms:"client_origin_server_id"`
+}
+
+// Whoami returns information about the current connection including the currently selected virtual server.
+func (c *Client) Whoami() (*ConnectionInfo, error) {
+	i := &ConnectionInfo{}
+	if _, err := c.ExecCmd(NewCmd("whoami").WithResponse(&i)); err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}

--- a/basic_cmds_test.go
+++ b/basic_cmds_test.go
@@ -54,6 +54,29 @@ func TestCmdsBasic(t *testing.T) {
 		assert.NoError(t, c.UsePort(1024))
 	}
 
+	whoami := func(t *testing.T) {
+		info, err := c.Whoami()
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		expected := &ConnectionInfo{
+			ServerStatus:           "online",
+			ServerID:               18,
+			ServerUniqueIdentifier: "gNITtWtKs9+Uh3L4LKv8/YHsn5c=",
+			ServerPort:             9987,
+			ClientID:               94,
+			ClientChannelID:        432,
+			ClientName:             "serveradmin from 127.0.0.1:49725",
+			ClientDatabaseID:       1,
+			ClientLoginName:        "serveradmin",
+			ClientUniqueIdentifier: "serveradmin",
+			ClientOriginServerID:   0,
+		}
+
+		assert.Equal(t, expected, info)
+	}
+
 	tests := []struct {
 		name string
 		f    func(t *testing.T)
@@ -61,7 +84,8 @@ func TestCmdsBasic(t *testing.T) {
 		{"auth", auth},
 		{"version", version},
 		{"useid", useID},
-		{"userport", usePort},
+		{"useport", usePort},
+		{"whoami", whoami},
 	}
 
 	for _, tc := range tests {

--- a/mockserver_test.go
+++ b/mockserver_test.go
@@ -40,6 +40,7 @@ var (
 		"channellist":                 "cid=499 pid=0 channel_order=0 channel_name=Default\\sChannel total_clients=1 channel_needed_subscribe_power=0",
 		"clientlist":                  "clid=5 cid=7 client_database_id=40 client_nickname=ScP client_type=0 client_away=1 client_away_message=not\\shere",
 		"clientdblist":                "cldbid=7 client_unique_identifier=DZhdQU58qyooEK4Fr8Ly738hEmc= client_nickname=MuhChy client_created=1259147468 client_lastconnected=1259421233",
+		"whoami":                      "virtualserver_status=online virtualserver_id=18 virtualserver_unique_identifier=gNITtWtKs9+Uh3L4LKv8\\/YHsn5c= virtualserver_port=9987 client_id=94 client_channel_id=432 client_nickname=serveradmin\\sfrom\\s127.0.0.1:49725 client_database_id=1 client_login_name=serveradmin client_unique_identifier=serveradmin client_origin_server_id=0",
 		cmdQuit:                       "",
 	}
 )


### PR DESCRIPTION
Added support for the whoami command which returns information about the current connection.

Credit goes to @thannaske for the original versions of this.

Also:
* Corrected typo in useport test name.