### PR TITLE
Allow ClientQuery connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,8 +20,7 @@ const (
 	// to commands such as serversnapshotcreate.
 	MaxParseTokenSize = 10 << 20
 
-	// DefaultConnectHeader is send by server on connect. User "TS3 Client" if using
-	// client query
+	// DefaultConnectHeader send by server on connect.
 	DefaultConnectHeader = "TS3"
 
 	// startBufSize is the initial size of allocation for the parse buffer.
@@ -103,9 +102,9 @@ func Buffer(buf []byte, max int) func(*Client) error {
 	}
 }
 
-// ConnectHeader sets the header expected by the client on connect.
+// ConnectHeader sets the header expected on connect.
 //
-// Default is "TS3" which is sent by server query. For clien query
+// Default is "TS3" which is sent by server query. For client query
 // use "TS3 Client".
 func ConnectHeader(connectHeader string) func(*Client) error {
 	return func(c *Client) error {

--- a/mockserver_test.go
+++ b/mockserver_test.go
@@ -180,7 +180,7 @@ func (s *server) handle(conn net.Conn) {
 				return
 			}
 		} else {
-			if err := s.write(conn, connectHeader); err != nil {
+			if err := s.write(conn, DefaultConnectHeader); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
ServerQuery and ClientQuery are pretty similar. The only differences are the commands and  the header send on a new connection. ServerQuery sends "TS3" and ClientQuery "TS3 Client". Custom commands work create, but the connection header was hardcoded. 

I moved connectHeader into the Client struct and added an option to set it in NewClient(...).